### PR TITLE
Fix Web vs Local Args

### DIFF
--- a/src/web_app.py
+++ b/src/web_app.py
@@ -230,15 +230,15 @@ def page_settings(state):
 
     st.markdown("#### Choose dataset size to train models with:")
     options = ["5d", "1mo", "3mo", "6mo", "1y", "5y", "10y", "max"]
-    if run_location == "web":
+    if run_location == "local":
         state.period = st.radio(
-            "Choose amount of historical training data. 1 year is recommended, find more recommendations on homepage.",
+            "Choose amount of historical training data. Recommended data lengths/models for these data lengths can be found on the home screen. Overall, for most models 1-year of data seems to be most optimal.",
             options,
             options.index(state.radio) if state.radio else 0,
         )
     else:
         state.period = st.radio(
-            "Choose amount of historical training data. Recommended data lengths/models for these data lengths can be found on the home screen. Overall, for most models 1-year of data seems to be most optimal.",
+            "Choose amount of historical training data. 1 year is recommended, find more recommendations on homepage.",
             options,
             options.index(state.radio) if state.radio else 0,
         )
@@ -256,7 +256,7 @@ def page_settings(state):
     if state.run == True:
         st.markdown("## *Go to the dashboard to view your newly scraped data data.*")
 
-        if run_location != "web":
+        if run_location == "local":
             st.markdown("### Export Options")
             if st.checkbox("Would you like to export results?", state.export_checkbox):
                 state.export_checkbox = True

--- a/src/web_app.py
+++ b/src/web_app.py
@@ -13,9 +13,12 @@ import json_handler
 import prediction
 import scraper
 
-run_location = sys.argv[
-    1
-]  # determine whether it was run online or locally by system args
+if len(sys.argv) > 1:
+    run_location = sys.argv[
+        1
+    ]  # determine whether it was run online or locally by system args
+else:
+    run_location = "web"
 
 try:
     # Before Streamlit 0.65


### PR DESCRIPTION
Fixes the way arguments are called for Streamlit UI when used local vs web.

Local users will automatically have the "local" arg added to the call to the streamlit web app and the UI will be formatted for local use.

There is no "web" arg, but if there are no extra arguments we assume it is being run by streamlit web hosting so the tool is formatted for web use.